### PR TITLE
feat: remove PoR executor from risk admins

### DIFF
--- a/scripts/Deploy.s.sol
+++ b/scripts/Deploy.s.sol
@@ -13,6 +13,7 @@ import {AaveV3BNB} from 'aave-address-book/AaveV3BNB.sol';
 import {AaveV3Scroll} from 'aave-address-book/AaveV3Scroll.sol';
 import {IPoolAddressesProvider} from 'aave-v3-origin/core/contracts/interfaces/IPoolAddressesProvider.sol';
 import {AaveProtocolDataProvider} from 'aave-v3-origin/core/contracts/misc/AaveProtocolDataProvider.sol';
+import {PoolConfiguratorInstance} from 'aave-v3-origin/core/instances/PoolConfiguratorInstance.sol';
 import {PoolInstanceWithCustomInitialize} from '../src/contracts/PoolInstanceWithCustomInitialize.sol';
 import {L2PoolInstanceWithCustomInitialize} from '../src/contracts/L2PoolInstanceWithCustomInitialize.sol';
 import {UpgradePayload} from '../src/contracts/UpgradePayload.sol';
@@ -27,7 +28,14 @@ library DeploymentLibrary {
     address poolImpl = address(
       new L2PoolInstanceWithCustomInitialize(IPoolAddressesProvider(poolAddressesProvider))
     );
-    return _deployPayload(poolAddressesProvider, pool, poolConfigurator, poolImpl, proofOfReserveExecutor);
+    return
+      _deployPayload(
+        poolAddressesProvider,
+        pool,
+        poolConfigurator,
+        poolImpl,
+        proofOfReserveExecutor
+      );
   }
 
   function _deployL1(
@@ -39,7 +47,14 @@ library DeploymentLibrary {
     address poolImpl = address(
       new PoolInstanceWithCustomInitialize(IPoolAddressesProvider(poolAddressesProvider))
     );
-    return _deployPayload(poolAddressesProvider, pool, poolConfigurator, poolImpl, proofOfReserveExecutor);
+    return
+      _deployPayload(
+        poolAddressesProvider,
+        pool,
+        poolConfigurator,
+        poolImpl,
+        proofOfReserveExecutor
+      );
   }
 
   function _deployPayload(
@@ -49,6 +64,7 @@ library DeploymentLibrary {
     address poolImpl,
     address proofOfReserveExecutor
   ) internal returns (address) {
+    address poolConfiguratorImpl = address(new PoolConfiguratorInstance());
     address poolDataProvider = address(
       new AaveProtocolDataProvider(IPoolAddressesProvider(poolAddressesProvider))
     );
@@ -60,6 +76,7 @@ library DeploymentLibrary {
           pool,
           poolConfigurator,
           poolImpl,
+          poolConfiguratorImpl,
           poolDataProvider,
           proofOfReserveExecutor
         )

--- a/scripts/Deploy.s.sol
+++ b/scripts/Deploy.s.sol
@@ -21,30 +21,33 @@ library DeploymentLibrary {
   function _deployL2(
     address poolAddressesProvider,
     address pool,
-    address poolConfigurator
+    address poolConfigurator,
+    address proofOfReserveExecutor
   ) internal returns (address) {
     address poolImpl = address(
       new L2PoolInstanceWithCustomInitialize(IPoolAddressesProvider(poolAddressesProvider))
     );
-    return _deployPayload(poolAddressesProvider, pool, poolConfigurator, poolImpl);
+    return _deployPayload(poolAddressesProvider, pool, poolConfigurator, poolImpl, proofOfReserveExecutor);
   }
 
   function _deployL1(
     address poolAddressesProvider,
     address pool,
-    address poolConfigurator
+    address poolConfigurator,
+    address proofOfReserveExecutor
   ) internal returns (address) {
     address poolImpl = address(
       new PoolInstanceWithCustomInitialize(IPoolAddressesProvider(poolAddressesProvider))
     );
-    return _deployPayload(poolAddressesProvider, pool, poolConfigurator, poolImpl);
+    return _deployPayload(poolAddressesProvider, pool, poolConfigurator, poolImpl, proofOfReserveExecutor);
   }
 
   function _deployPayload(
     address poolAddressesProvider,
     address pool,
     address poolConfigurator,
-    address poolImpl
+    address poolImpl,
+    address proofOfReserveExecutor
   ) internal returns (address) {
     address poolDataProvider = address(
       new AaveProtocolDataProvider(IPoolAddressesProvider(poolAddressesProvider))
@@ -57,7 +60,8 @@ library DeploymentLibrary {
           pool,
           poolConfigurator,
           poolImpl,
-          poolDataProvider
+          poolDataProvider,
+          proofOfReserveExecutor
         )
       );
   }
@@ -67,7 +71,8 @@ library DeploymentLibrary {
       _deployL1(
         address(AaveV3Polygon.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Polygon.POOL),
-        address(AaveV3Polygon.POOL_CONFIGURATOR)
+        address(AaveV3Polygon.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 
@@ -76,7 +81,8 @@ library DeploymentLibrary {
       _deployL1(
         address(AaveV3Ethereum.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Ethereum.POOL),
-        address(AaveV3Ethereum.POOL_CONFIGURATOR)
+        address(AaveV3Ethereum.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 
@@ -85,7 +91,8 @@ library DeploymentLibrary {
       _deployL1(
         address(AaveV3Avalanche.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Avalanche.POOL),
-        address(AaveV3Avalanche.POOL_CONFIGURATOR)
+        address(AaveV3Avalanche.POOL_CONFIGURATOR),
+        AaveV3Avalanche.PROOF_OF_RESERVE
       );
   }
 
@@ -94,7 +101,8 @@ library DeploymentLibrary {
       _deployL2(
         address(AaveV3Arbitrum.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Arbitrum.POOL),
-        address(AaveV3Arbitrum.POOL_CONFIGURATOR)
+        address(AaveV3Arbitrum.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 
@@ -103,7 +111,8 @@ library DeploymentLibrary {
       _deployL2(
         address(AaveV3Optimism.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Optimism.POOL),
-        address(AaveV3Optimism.POOL_CONFIGURATOR)
+        address(AaveV3Optimism.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 
@@ -112,7 +121,8 @@ library DeploymentLibrary {
       _deployL2(
         address(AaveV3Base.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Base.POOL),
-        address(AaveV3Base.POOL_CONFIGURATOR)
+        address(AaveV3Base.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 
@@ -121,7 +131,8 @@ library DeploymentLibrary {
       _deployL1(
         address(AaveV3Gnosis.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Gnosis.POOL),
-        address(AaveV3Gnosis.POOL_CONFIGURATOR)
+        address(AaveV3Gnosis.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 
@@ -130,7 +141,8 @@ library DeploymentLibrary {
       _deployL2(
         address(AaveV3Metis.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Metis.POOL),
-        address(AaveV3Metis.POOL_CONFIGURATOR)
+        address(AaveV3Metis.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 
@@ -139,7 +151,8 @@ library DeploymentLibrary {
       _deployL1(
         address(AaveV3BNB.POOL_ADDRESSES_PROVIDER),
         address(AaveV3BNB.POOL),
-        address(AaveV3BNB.POOL_CONFIGURATOR)
+        address(AaveV3BNB.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 
@@ -148,7 +161,8 @@ library DeploymentLibrary {
       _deployL2(
         address(AaveV3Scroll.POOL_ADDRESSES_PROVIDER),
         address(AaveV3Scroll.POOL),
-        address(AaveV3Scroll.POOL_CONFIGURATOR)
+        address(AaveV3Scroll.POOL_CONFIGURATOR),
+        address(0)
       );
   }
 }

--- a/src/contracts/UpgradePayload.sol
+++ b/src/contracts/UpgradePayload.sol
@@ -7,7 +7,7 @@ import {IPoolConfigurator} from 'aave-v3-origin/core/contracts/interfaces/IPoolC
 import {PoolConfiguratorInstance} from 'aave-v3-origin/core/instances/PoolConfiguratorInstance.sol';
 import {DefaultReserveInterestRateStrategyV2} from 'aave-v3-origin/core/contracts/protocol/pool/DefaultReserveInterestRateStrategyV2.sol';
 import {IDefaultInterestRateStrategyV2} from 'aave-v3-origin/core/contracts/interfaces/IDefaultInterestRateStrategyV2.sol';
-import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3EthereumAssets, IACLManager} from 'aave-address-book/AaveV3Ethereum.sol';
 
 interface ILegacyDefaultInterestRateStrategy {
   /**
@@ -45,13 +45,15 @@ contract UpgradePayload is IProposalGenericExecutor {
 
   address public immutable POOL_IMPL;
   address public immutable POOL_DATA_PROVIDER;
+  address public immutable PROOF_OF_RESERVE_EXECUTOR;
 
   constructor(
     address poolAddressesProvider,
     address pool,
     address configurator,
     address poolImpl,
-    address poolDataProvider
+    address poolDataProvider,
+    address proofOfReserveExecutor
   ) {
     POOL_ADDRESSES_PROVIDER = IPoolAddressesProvider(poolAddressesProvider);
     POOL = IPool(pool);
@@ -59,6 +61,7 @@ contract UpgradePayload is IProposalGenericExecutor {
     DEFAULT_IR = new DefaultReserveInterestRateStrategyV2(address(poolAddressesProvider));
     POOL_IMPL = poolImpl;
     POOL_DATA_PROVIDER = poolDataProvider;
+    PROOF_OF_RESERVE_EXECUTOR = proofOfReserveExecutor;
   }
 
   function execute() external {
@@ -102,5 +105,10 @@ contract UpgradePayload is IProposalGenericExecutor {
         )
       );
     }
+
+      if (PROOF_OF_RESERVE_EXECUTOR != address(0)) {
+        IACLManager(POOL_ADDRESSES_PROVIDER.getACLManager()).removeRiskAdmin(PROOF_OF_RESERVE_EXECUTOR);
+
+      }
   }
 }

--- a/src/contracts/UpgradePayload.sol
+++ b/src/contracts/UpgradePayload.sol
@@ -106,9 +106,10 @@ contract UpgradePayload is IProposalGenericExecutor {
       );
     }
 
-      if (PROOF_OF_RESERVE_EXECUTOR != address(0)) {
-        IACLManager(POOL_ADDRESSES_PROVIDER.getACLManager()).removeRiskAdmin(PROOF_OF_RESERVE_EXECUTOR);
-
-      }
+    if (PROOF_OF_RESERVE_EXECUTOR != address(0)) {
+      IACLManager(POOL_ADDRESSES_PROVIDER.getACLManager()).removeRiskAdmin(
+        PROOF_OF_RESERVE_EXECUTOR
+      );
+    }
   }
 }

--- a/src/contracts/UpgradePayload.sol
+++ b/src/contracts/UpgradePayload.sol
@@ -4,7 +4,6 @@ import {IProposalGenericExecutor} from 'aave-helpers/interfaces/IProposalGeneric
 import {IPoolAddressesProvider} from 'aave-v3-origin/core/contracts/interfaces/IPoolAddressesProvider.sol';
 import {IPool, DataTypes} from 'aave-v3-origin/core/contracts/interfaces/IPool.sol';
 import {IPoolConfigurator} from 'aave-v3-origin/core/contracts/interfaces/IPoolConfigurator.sol';
-import {PoolConfiguratorInstance} from 'aave-v3-origin/core/instances/PoolConfiguratorInstance.sol';
 import {DefaultReserveInterestRateStrategyV2} from 'aave-v3-origin/core/contracts/protocol/pool/DefaultReserveInterestRateStrategyV2.sol';
 import {IDefaultInterestRateStrategyV2} from 'aave-v3-origin/core/contracts/interfaces/IDefaultInterestRateStrategyV2.sol';
 import {AaveV3EthereumAssets, IACLManager} from 'aave-address-book/AaveV3Ethereum.sol';
@@ -44,6 +43,7 @@ contract UpgradePayload is IProposalGenericExecutor {
   DefaultReserveInterestRateStrategyV2 public immutable DEFAULT_IR;
 
   address public immutable POOL_IMPL;
+  address public immutable POOL_CONFIGURATOR_IMPL;
   address public immutable POOL_DATA_PROVIDER;
   address public immutable PROOF_OF_RESERVE_EXECUTOR;
 
@@ -52,6 +52,7 @@ contract UpgradePayload is IProposalGenericExecutor {
     address pool,
     address configurator,
     address poolImpl,
+    address poolConfiguratorImpl,
     address poolDataProvider,
     address proofOfReserveExecutor
   ) {
@@ -60,12 +61,13 @@ contract UpgradePayload is IProposalGenericExecutor {
     CONFIGURATOR = IPoolConfigurator(configurator);
     DEFAULT_IR = new DefaultReserveInterestRateStrategyV2(address(poolAddressesProvider));
     POOL_IMPL = poolImpl;
+    POOL_CONFIGURATOR_IMPL = poolConfiguratorImpl;
     POOL_DATA_PROVIDER = poolDataProvider;
     PROOF_OF_RESERVE_EXECUTOR = proofOfReserveExecutor;
   }
 
   function execute() external {
-    POOL_ADDRESSES_PROVIDER.setPoolConfiguratorImpl(address(new PoolConfiguratorInstance()));
+    POOL_ADDRESSES_PROVIDER.setPoolConfiguratorImpl(POOL_CONFIGURATOR_IMPL);
     POOL_ADDRESSES_PROVIDER.setPoolImpl(POOL_IMPL);
     POOL_ADDRESSES_PROVIDER.setPoolDataProvider(POOL_DATA_PROVIDER);
 

--- a/tests/UpgradeAvalancheTest.t.sol
+++ b/tests/UpgradeAvalancheTest.t.sol
@@ -15,6 +15,10 @@ contract UpgradeAvalancheTest is
     5 * 1e3 // limit raised to 0.05%, because of FRAX(0.016%) and MAI(0.05%)
   )
 {
+  function test_proofOfReserveExecutor_riskAdmin_removed() public proposalExecuted {
+    assertFalse(AaveV3Avalanche.ACL_MANAGER.isRiskAdmin(PAYLOAD.PROOF_OF_RESERVE_EXECUTOR()));
+  }
+
   function _getPayload() internal virtual override returns (address) {
     return DeploymentLibrary._deployAvalanche();
   }


### PR DESCRIPTION
We are removing Por Executor for Avalanche V3 from risk admins to prevent it from executing before it is upgraded to align with v3.1