### PR TITLE
Revert GHO IR-logic branch change on Arbitrum

### DIFF
--- a/src/contracts/UpgradePayload.sol
+++ b/src/contracts/UpgradePayload.sol
@@ -7,7 +7,6 @@ import {IPoolConfigurator} from 'aave-v3-origin/core/contracts/interfaces/IPoolC
 import {DefaultReserveInterestRateStrategyV2} from 'aave-v3-origin/core/contracts/protocol/pool/DefaultReserveInterestRateStrategyV2.sol';
 import {IDefaultInterestRateStrategyV2} from 'aave-v3-origin/core/contracts/interfaces/IDefaultInterestRateStrategyV2.sol';
 import {AaveV3EthereumAssets, IACLManager} from 'aave-address-book/AaveV3Ethereum.sol';
-import {AaveV3ArbitrumAssets} from 'aave-address-book/AaveV3Arbitrum.sol';
 import {ReserveConfiguration} from 'aave-v3-origin/core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol';
 
 interface ILegacyDefaultInterestRateStrategy {
@@ -89,10 +88,7 @@ contract UpgradePayload is IProposalGenericExecutor {
         CONFIGURATOR.setReserveFreeze(reserves[i], true);
       }
 
-      if (
-        reserves[i] == AaveV3EthereumAssets.GHO_UNDERLYING ||
-        reserves[i] == AaveV3ArbitrumAssets.GHO_UNDERLYING
-      ) {
+      if (reserves[i] == AaveV3EthereumAssets.GHO_UNDERLYING) {
         currentUOpt = DEFAULT_IR.MAX_OPTIMAL_POINT();
       } else {
         currentUOpt =

--- a/tests/UpgradeArbitrumTest.t.sol
+++ b/tests/UpgradeArbitrumTest.t.sol
@@ -9,7 +9,7 @@ import {UpgradePayloadTestWithStableSwap} from './UpgradePayloadTestWithStableSw
 contract UpgradeArbitrumTest is
   UpgradePayloadTestWithStableSwap(
     'arbitrum',
-    232545374,
+    234849726,
     0x62B8e137ee87Ab3CaEB2FEA3B88D04abeA7C5579,
     AaveV3ArbitrumAssets.USDC_UNDERLYING,
     1.5 * 1e3 // limit is 0.015%


### PR DESCRIPTION
GHO on Arbitrum behaves like any other asset listed interest-rate strategy wise. So there is no need to add any exception for it on the payload